### PR TITLE
issue_869: Fixed infinity loading status of attachments

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "JDN",
   "description": "JDN – helps Test Automation Engineer to create Page Objects in the test automation framework and speed up test development",
   "devtools_page": "index.html",
-  "version": "3.6.333",
+  "version": "3.6.334",
   "icons": {
     "128": "icon128.png"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "JDN",
   "description": "JDN – helps Test Automation Engineer to create Page Objects in the test automation framework and speed up test development",
   "devtools_page": "index.html",
-  "version": "3.6.334",
+  "version": "3.6.335",
   "icons": {
     "128": "icon128.png"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jdn-ai-chrome-extension",
-  "version": "3.6.334",
+  "version": "3.6.335",
   "description": "jdn-ai chrome extension",
   "scripts": {
     "start": "webpack --watch --env devenv",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jdn-ai-chrome-extension",
-  "version": "3.6.333",
+  "version": "3.6.334",
   "description": "jdn-ai chrome extension",
   "scripts": {
     "start": "webpack --watch --env devenv",

--- a/src/features/reportProblem/ReportProblem.tsx
+++ b/src/features/reportProblem/ReportProblem.tsx
@@ -177,7 +177,10 @@ export const ReportProblem = () => {
         <DialogWithForm
           modalProps={{
             okButtonProps: {
-              disabled: fileList.length > MAX_COUNT_FILES || filesSize > MAX_FILES_SIZE_MB,
+              disabled:
+                fileList.length > MAX_COUNT_FILES ||
+                filesSize > MAX_FILES_SIZE_MB ||
+                fileList.some((file) => file.status === "error"),
             },
             title: "Report a problem",
             open: isModalOpen,
@@ -251,7 +254,7 @@ export const ReportProblem = () => {
               </React.Fragment>
             }
           >
-            <Upload name="attachments" onChange={handleUploadChange} {...{ fileList }} multiple>
+            <Upload name="attachments" onChange={handleUploadChange} multiple>
               <Tooltip
                 placement="right"
                 title={getTextforUploadButtonTooltip()}

--- a/src/pageServices/contentScripts/css/contextMenu.less
+++ b/src/pageServices/contentScripts/css/contextMenu.less
@@ -41,6 +41,16 @@ div[id^="jdn_cm_"] {
       box-sizing: border-box;
     }
 
+    &.cm_border_right > ul ul {
+      left: unset;
+      right: 100%;
+    }
+
+    &.cm_border_bottom > ul ul {
+      top: unset;
+      bottom: 0;
+    }
+
     ul {
       list-style-type: none;
       padding: 0;
@@ -133,16 +143,6 @@ div[id^="jdn_cm_"] {
         &:hover {
           background-color: inherit;
         }
-      }
-
-      &.cm_border_right > ul ul {
-        left: unset;
-        right: 100%;
-      }
-
-      &.cm_border_bottom > ul ul {
-        top: unset;
-        bottom: 0;
       }
 
       &[disabled=""] {


### PR DESCRIPTION
known issue antd library
https://github.com/ant-design/ant-design/issues/2423

If we refuse from `fileList` prop it will work as expected in our case.

Additional validation in case if any file has "error" status was added as well