### PR TITLE
issue 1368: fix select logic when context menu had opened

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "JDN",
   "description": "JDN – helps Test Automation Engineer to create Page Objects in the test automation framework and speed up test development",
   "devtools_page": "index.html",
-  "version": "3.13.540",
+  "version": "3.13.541",
   "icons": {
     "128": "icon128.png"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jdn-ai-chrome-extension",
-  "version": "3.13.540",
+  "version": "3.13.541",
   "description": "jdn-ai chrome extension",
   "scripts": {
     "start": "webpack --watch --env devenv",

--- a/src/pageServices/contentScripts/contextmenu.js
+++ b/src/pageServices/contentScripts/contextmenu.js
@@ -85,7 +85,7 @@ export const runContextMenu = () => {
     this.reload = function () {
       if (document.getElementById("jdn_cm_" + num) == null) {
         const cnt = document.createElement("div");
-        cnt.className = "cm_container";
+        cnt.className = "cm_container context-menu";
         cnt.id = "jdn_cm_" + num;
 
         document.body.appendChild(cnt);

--- a/src/pageServices/contentScripts/selectable.js
+++ b/src/pageServices/contentScripts/selectable.js
@@ -176,6 +176,9 @@ export const selectable = () => {
       const labelTarget = e.target.closest(".jdn-label");
       if (labelTarget) return;
 
+      const menuTarget = e.target.closest(".context-menu");
+      if (menuTarget) return;
+
       self.options.start && self.options.start(e);
       if (self.options.key && !e[self.options.key]) return;
       self.options.onDeselect && self.selectedItems.size && self.options.onDeselect(Array.from(self.selectedItems));


### PR DESCRIPTION
Исправлена логика unselect для ситуаций вызова контекстного меню на выделенных блоках
https://github.com/jdi-testing/jdn-ai/issues/1368
