### PR TITLE
 issue_1398: add initial state STARTED in jdn-status attr for all locators

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "JDN",
   "description": "JDN – helps Test Automation Engineer to create Page Objects in the test automation framework and speed up test development",
   "devtools_page": "index.html",
-  "version": "3.13.555",
+  "version": "3.13.556",
   "icons": {
     "128": "icon128.png"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jdn-ai-chrome-extension",
-  "version": "3.13.555",
+  "version": "3.13.556",
   "description": "jdn-ai chrome extension",
   "scripts": {
     "start": "webpack --watch --env devenv",

--- a/src/features/locators/reducers/identifyElements.thunk.ts
+++ b/src/features/locators/reducers/identifyElements.thunk.ts
@@ -74,6 +74,7 @@ export const onLocatorsCreated: Middleware = (store) => (next) => (action) => {
     const locators = action.payload;
     const { generateXpath } = selectAutoGeneratingLocatorTypes(state as RootState, locators);
     // generateCssSelector: false because it's run with attributes generation for performance reasons
+    // TODO: take generateCssSelector from selectAutoGeneratingLocatorTypes, when backend will be ready
     // @ts-ignore
     store.dispatch(runLocatorsGeneration({ locators, generateXpath, generateCssSelector: false }));
   }

--- a/src/pageServices/contentScripts/highlight.js
+++ b/src/pageServices/contentScripts/highlight.js
@@ -234,7 +234,7 @@ export const highlightOnPage = () => {
     div.id = jdnHash;
     div.className = getClassName(predictedElement);
     div.setAttribute("jdn-highlight", true);
-    div.setAttribute("jdn-status", predictedElement.locator.taskStatus);
+    div.setAttribute("jdn-status", predictedElement.locator.taskStatus || LocatorTaskStatus.STARTED);
     div.addEventListener("mouseover", () => {
       tooltipTimer = setTimeout(() => {
         showTooltip(coordinates);


### PR DESCRIPTION
https://github.com/jdi-testing/jdn-ai/issues/1398
Добавила статус STARTED как initial статус для всех областей покрытия (если нет своего статуа locator.taskStatus ) 
