### PR TITLE
Issue 1535: fix layout order for jdn-highlights blocks

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "JDN",
   "description": "JDN – helps Test Automation Engineer to create Page Objects in the test automation framework and speed up test development",
   "devtools_page": "index.html",
-  "version": "3.14.14",
+  "version": "3.14.15",
   "icons": {
     "128": "icon128.png"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jdn-ai-chrome-extension",
-  "version": "3.14.14",
+  "version": "3.14.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jdn-ai-chrome-extension",
-      "version": "3.14.14",
+      "version": "3.14.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jdn-ai-chrome-extension",
-  "version": "3.14.14",
+  "version": "3.14.15",
   "description": "jdn-ai chrome extension",
   "scripts": {
     "start": "webpack --watch --env devenv",

--- a/src/features/locators/Locator.tsx
+++ b/src/features/locators/Locator.tsx
@@ -47,7 +47,6 @@ interface Props {
   searchString?: string;
 }
 
-// eslint-disable-next-line react/display-name
 export const Locator: React.FC<Props> = ({ element, currentPage, searchState, depth, searchString }) => {
   const dispatch = useDispatch();
 

--- a/src/pageServices/contentScripts/css/highlight.less
+++ b/src/pageServices/contentScripts/css/highlight.less
@@ -11,7 +11,7 @@ div[jdn-highlight="true"] {
 
 &.jdn-highlight {
   position: absolute;
-  z-index: 5000;
+  z-index: 15000;
   color: rgba(255, 255, 255, 1);
   font-family: @font-family;
   font-size: 9px;


### PR DESCRIPTION
https://github.com/jdi-testing/jdn-ai/issues/1535
Вытащила все highlight блоки на 15000+ уровень, теперь если на странице меньше 15000 DOM-узлов, jdn-блоки всегда будут поверх
![image](https://github.com/jdi-testing/jdn-ai/assets/50149163/85343c19-af2a-4c5b-81e3-32e808ed6cf4)
