### PR TITLE
Issue 1287: update "-predict" endpoint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,6 +54,8 @@
     "@typescript-eslint/no-unsafe-assignment": "off",
     "@typescript-eslint/no-unsafe-argument": "off",
     "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-return": "off",
+    "@typescript-eslint/no-unsafe-call": "off",
     "@typescript-eslint/no-non-null-assertion": "warn",
     "@typescript-eslint/no-unused-vars": ["error", { "args": "after-used", "argsIgnorePattern": "_", "varsIgnorePattern": "_" }],
     "@typescript-eslint/ban-ts-comment": "warn"

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "JDN",
   "description": "JDN – helps Test Automation Engineer to create Page Objects in the test automation framework and speed up test development",
   "devtools_page": "index.html",
-  "version": "3.14.21",
+  "version": "3.14.22",
   "icons": {
     "128": "icon128.png"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jdn-ai-chrome-extension",
-  "version": "3.14.21",
+  "version": "3.14.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jdn-ai-chrome-extension",
-      "version": "3.14.21",
+      "version": "3.14.22",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jdn-ai-chrome-extension",
-  "version": "3.14.21",
+  "version": "3.14.22",
   "description": "jdn-ai chrome extension",
   "scripts": {
     "start": "webpack --watch --env devenv",

--- a/src/__tests__/__mocks__/locator.mock.js
+++ b/src/__tests__/__mocks__/locator.mock.js
@@ -1,6 +1,7 @@
 export const locator1 = {
   attrId: '',
   element_id: '8736312404689610766421832473',
+  is_shown: true,
   height: 201.3333435059,
   locator: {
     xPath: "//*[@class='sidebar-menu left']",
@@ -25,6 +26,7 @@ export const locator1 = {
 export const locator2 = {
   attrId: '',
   element_id: '2222222222',
+  is_shown: true,
   height: 201.3333435059,
   locator: {
     xPath: "//*[@class='sidebar-menu left']",
@@ -46,6 +48,7 @@ export const locator2 = {
 export const locator3 = {
   attrId: '',
   element_id: '333333333333333',
+  is_shown: true,
   height: 201.3333435059,
   locator: {
     xPath: "//*[@class='sidebar-menu left']",

--- a/src/__tests__/__mocks__/pageObjectMocks/elementsWithoutNames.js
+++ b/src/__tests__/__mocks__/pageObjectMocks/elementsWithoutNames.js
@@ -1,6 +1,7 @@
 export const elementsWithoutNames = [
   {
     element_id: '7824983223872788250093302805',
+    is_shown: true,
     predicted_label: 'radiogroup',
     elemId: 'radio79',
     elemName: 'radio78',
@@ -11,6 +12,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '3976799717872788243800691939',
+    is_shown: true,
     predicted_label: 'list',
     elemId: 'radio79',
     elemName: 'radio78',
@@ -21,6 +23,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '2531946027872788259730157905',
+    is_shown: true,
     predicted_label: 'list',
     elemId: 'radio79',
     elemName: 'radio78',
@@ -31,6 +34,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '1788878284872788254954433922',
+    is_shown: true,
     predicted_label: 'badge',
     elemId: 'anyNymber',
     elemName: '',
@@ -41,6 +45,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '8073262067872788257041578300',
+    is_shown: true,
     predicted_label: 'chip',
     elemId: '',
     elemName: 'chipOfTheChips',
@@ -51,6 +56,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '8162387396872788255600213565',
+    is_shown: true,
     predicted_label: 'chip',
     elemId: '',
     elemName: 'chipOfTheChips',
@@ -61,6 +67,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '3824832072872788248203820469',
+    is_shown: true,
     predicted_label: 'badge',
     elemId: 'anyNymber',
     elemName: '',
@@ -71,6 +78,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '1195797979872788259469412332',
+    is_shown: true,
     predicted_label: 'list',
     elemId: '',
     elemName: '',
@@ -81,6 +89,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '1195797979872788259469412444',
+    is_shown: true,
     predicted_label: 'list',
     elemId: '',
     elemName: '',
@@ -91,6 +100,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '3265985627872788257228708643',
+    is_shown: true,
     predicted_label: 'button',
     locator: {
       fullXpath: '/html/body/header/div/nav/ul[2]/li/div/div/button',
@@ -98,6 +108,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '3901491381872788252561828171',
+    is_shown: true,
     predicted_label: 'button',
     elemId: '1001loginButton',
     locator: {
@@ -106,6 +117,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '9384531537872788240323543297',
+    is_shown: true,
     predicted_label: 'menu',
     elemId: '   menu Foo  ',
     locator: {
@@ -114,6 +126,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '3901491381872788252561828179',
+    is_shown: true,
     predicted_label: 'button',
     elemId: '1001loginButton',
     locator: {
@@ -122,6 +135,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '1195797979872788259469412450',
+    is_shown: true,
     predicted_label: 'list',
     elemId: '',
     elemName: '',
@@ -132,6 +146,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '1195797979872788259469412460',
+    is_shown: true,
     predicted_label: 'list',
     elemId: '',
     elemName: '',
@@ -142,6 +157,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '1195797979872788259469412460',
+    is_shown: true,
     predicted_label: 'list',
     elemId: '',
     elemName: '',
@@ -152,6 +168,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '1195797979872788259469412000',
+    is_shown: true,
     predicted_label: 'list',
     elemId: '',
     elemName: '',
@@ -162,6 +179,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '7824983223872788250093302',
+    is_shown: true,
     predicted_label: 'radiogroup',
     elemAriaLabel: 'Click this control',
     elemId: 'radio79',
@@ -171,6 +189,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '78249832238727882500933021',
+    is_shown: true,
     predicted_label: 'radiogroup',
     elemAriaLabel: 'Click this control with very long text text text text text text text text text 123',
     elemId: 'radio79',
@@ -180,6 +199,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '78249832238727882500933022',
+    is_shown: true,
     predicted_label: 'radiogroup',
     elemAriaLabel: 'Click this control with very long text text text text text text text text text 123',
     elemId: 'radio79',
@@ -189,6 +209,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '782498322387278825009330223',
+    is_shown: true,
     predicted_label: 'radiogroup',
     elemAriaLabel: 'Кнопка вызова единорога',
     elemId: 'unicorn',
@@ -198,6 +219,7 @@ export const elementsWithoutNames = [
   },
   {
     element_id: '782498322387278825009330200',
+    is_shown: true,
     predicted_label: 'radiogroup',
     elemText: 'A string with non-latin (любой) unicode character ’ we expect to exclude ',
     elemId: 'unicorn',

--- a/src/__tests__/__mocks__/pageObjectMocks/pageObject.mock.js
+++ b/src/__tests__/__mocks__/pageObjectMocks/pageObject.mock.js
@@ -5,6 +5,7 @@ export const getLocatorsByAnnotationType = (value) => {
     {
       attrId: '',
       element_id: '0955274655778840492142094709',
+      is_shown: true,
       height: 60,
       locator: {
         fullXpath: '/html/body/header/div/nav/ul[1]',
@@ -27,6 +28,7 @@ export const getLocatorsByAnnotationType = (value) => {
     {
       attrId: '',
       element_id: '2022378243778840502461724770',
+      is_shown: true,
       height: 15.3333339691,
       locator: {
         fullXpath: '/html/body/footer/div/div/ul',
@@ -49,6 +51,7 @@ export const getLocatorsByAnnotationType = (value) => {
     {
       attrId: '',
       element_id: '2713188863778840498565585241',
+      is_shown: true,
       height: 38.6666679382,
       locator: {
         fullXpath: '/html/body/div/div[1]/div/div[1]/div/div[1]/ul/li[1]/a',
@@ -74,6 +77,7 @@ export const locators = [
   {
     attrId: '',
     element_id: '0955274655778840492142094709',
+    is_shown: true,
     height: 60,
     locator: {
       fullXpath: '/html/body/header/div/nav/ul[1]',
@@ -96,6 +100,7 @@ export const locators = [
   {
     attrId: '',
     element_id: '2022378243778840502461724770',
+    is_shown: true,
     height: 15.3333339691,
     locator: {
       fullXpath: '/html/body/footer/div/div/ul',
@@ -118,6 +123,7 @@ export const locators = [
   {
     attrId: '',
     element_id: '2713188863778840498565585241',
+    is_shown: true,
     height: 38.6666679382,
     locator: {
       fullXpath: '/html/body/div/div[1]/div/div[1]/div/div[1]/ul/li[1]/a',
@@ -142,6 +148,7 @@ export const locatorsWithFindBy = [
   {
     attrId: '',
     element_id: '0955274655778840492142094709',
+    is_shown: true,
     height: 60,
     locator: {
       fullXpath: '/html/body/header/div/nav/ul[1]',
@@ -164,6 +171,7 @@ export const locatorsWithFindBy = [
   {
     attrId: '',
     element_id: '2022378243778840502461724770',
+    is_shown: true,
     height: 15.3333339691,
     locator: {
       fullXpath: '/html/body/footer/div/div/ul',
@@ -186,6 +194,7 @@ export const locatorsWithFindBy = [
   {
     attrId: '',
     element_id: '2713188863778840498565585241',
+    is_shown: true,
     height: 38.6666679382,
     locator: {
       fullXpath: '/html/body/div/div[1]/div/div[1]/div/div[1]/ul/li[1]/a',
@@ -209,6 +218,7 @@ export const locatorsWithFindBy = [
 export const locatorsVividus = [
   {
     element_id: '0057770603115098154872149076_0',
+    is_shown: true,
     predicted_label: 'label',
     childs: ['1052464727115098158766915230'],
     displayed: false,
@@ -238,6 +248,7 @@ export const locatorsVividus = [
   },
   {
     element_id: '0735357117115098156691382591_0',
+    is_shown: true,
     predicted_label: 'label',
     childs: null,
     displayed: false,
@@ -271,6 +282,7 @@ export const locatorsVividus = [
   },
   {
     element_id: '0790139442115098150038335533_0',
+    is_shown: true,
     predicted_label: 'textarea',
     childs: null,
     displayed: false,
@@ -304,6 +316,7 @@ export const locatorsVividus = [
   },
   {
     element_id: '0928942213115098152027249027_0',
+    is_shown: true,
     predicted_label: 'label',
     childs: null,
     displayed: false,

--- a/src/__tests__/locators/locatorsSlice.test.js
+++ b/src/__tests__/locators/locatorsSlice.test.js
@@ -27,6 +27,7 @@ describe('changeLocatorAttributes reducer', () => {
     store.dispatch(
       changeLocatorAttributes({
         element_id: '8736312404689610766421832473',
+        is_shown: true,
         locator: "//*[@class='sidebar-menu left']",
         name: 'myAwesomeLocator',
         type: 'ProgressBar',
@@ -45,6 +46,7 @@ describe('changeLocatorAttributes reducer', () => {
     store.dispatch(
       changeLocatorAttributes({
         element_id: '8736312404689610766421832473',
+        is_shown: true,
         locator: "//*[@class='sidebar-menu left']",
         name: 'myAwesomeLocator',
         type: 'ProgressBar',
@@ -63,6 +65,7 @@ describe('changeLocatorAttributes reducer', () => {
     store.dispatch(
       changeLocatorAttributes({
         element_id: '8736312404689610766421832473',
+        is_shown: true,
         locator: "//*[@class='sidebar-menu left']",
         name: 'myAwesomeLocator',
         message: '',
@@ -81,6 +84,7 @@ describe('changeLocatorAttributes reducer', () => {
     store.dispatch(
       changeLocatorAttributes({
         element_id: '8736312404689610766421832473',
+        is_shown: true,
         locator: "//*[@class='any-class']",
         locatorType: LocatorType.xPath,
         name: 'myAwesomeLocator',
@@ -104,6 +108,7 @@ describe('changeLocatorAttributes reducer', () => {
     store.dispatch(
       changeLocatorAttributes({
         element_id: '8736312404689610766421832473',
+        is_shown: true,
         locator: "//*[@class='any-class112']",
         name: 'myAwesomeLocator',
         type: 'Dialog',

--- a/src/__tests__/locators/utils/__mocks__/locatorsList.mock.ts
+++ b/src/__tests__/locators/utils/__mocks__/locatorsList.mock.ts
@@ -6,6 +6,7 @@ import { LocatorType } from '../../../../common/types/common';
 export const locatorsListMock = [
   {
     element_id: '7967190244322359771369749968_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '',
@@ -28,6 +29,7 @@ export const locatorsListMock = [
   },
   {
     element_id: '3969471880322359761484771163_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '7967190244322359771369749968',
@@ -50,6 +52,7 @@ export const locatorsListMock = [
   },
   {
     element_id: '0045220328322359764482356698_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '3969471880322359761484771163',
@@ -72,6 +75,7 @@ export const locatorsListMock = [
   },
   {
     element_id: '6771529534322359778589411351_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '3969471880322359761484771163',
@@ -94,6 +98,7 @@ export const locatorsListMock = [
   },
   {
     element_id: '4899732051322359779677566872_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '7967190244322359771369749968',
@@ -116,6 +121,7 @@ export const locatorsListMock = [
   },
   {
     element_id: '4829071593322359778594168519_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '4899732051322359779677566872',
@@ -138,6 +144,7 @@ export const locatorsListMock = [
   },
   {
     element_id: '9636042053322359773245578788_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '4829071593322359778594168519',
@@ -160,6 +167,7 @@ export const locatorsListMock = [
   },
   {
     element_id: '8381553594322359777170267551_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '4829071593322359778594168519',
@@ -182,6 +190,7 @@ export const locatorsListMock = [
   },
   {
     element_id: '4899732051322359779677566873_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '7967190244322359771369749968',
@@ -204,6 +213,7 @@ export const locatorsListMock = [
   },
   {
     element_id: '4829071593322359778594168522_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '4899732051322359779677566873',
@@ -226,6 +236,7 @@ export const locatorsListMock = [
   },
   {
     element_id: '9636042053322359773245578777_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '4829071593322359778594168522',
@@ -248,6 +259,7 @@ export const locatorsListMock = [
   },
   {
     element_id: '8381553594322359777170267550_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '4829071593322359778594168522',
@@ -270,6 +282,7 @@ export const locatorsListMock = [
   },
   {
     element_id: '796719024432235977136974900_0',
+    is_shown: true,
     parent_id: '',
     jdnHash: '796719024432235977136974900',
     locator: {
@@ -297,6 +310,7 @@ export const locatorsListMock = [
 export const locatorsListMockForVividus = [
   {
     element_id: '7967190244322359771369749968_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '',
@@ -321,6 +335,7 @@ export const locatorsListMockForVividus = [
   },
   {
     element_id: '3969471880322359761484771163_0',
+    is_shown: true,
     isGenerated: true,
     pageObj: 0,
     parent_id: '7967190244322359771369749968',

--- a/src/__tests__/locators/utils/__mocks__/locatorsTree.mock.ts
+++ b/src/__tests__/locators/utils/__mocks__/locatorsTree.mock.ts
@@ -6,6 +6,7 @@ export const locatorsTreeMock = [
     depth: 0,
     searchState: undefined,
     element_id: '7967190244322359771369749968_0',
+    is_shown: true,
     parent_id: '',
     jdnHash: '7967190244322359771369749968',
     locator: {
@@ -30,6 +31,7 @@ export const locatorsTreeMock = [
         depth: 1,
         searchState: undefined,
         element_id: '3969471880322359761484771163_0',
+        is_shown: true,
         parent_id: '7967190244322359771369749968',
         jdnHash: '3969471880322359761484771163',
         locator: {
@@ -53,6 +55,7 @@ export const locatorsTreeMock = [
           {
             searchState: undefined,
             element_id: '0045220328322359764482356698_0',
+            is_shown: true,
             parent_id: '3969471880322359761484771163',
             jdnHash: '0045220328322359764482356698',
             locator: {
@@ -77,6 +80,7 @@ export const locatorsTreeMock = [
           },
           {
             element_id: '6771529534322359778589411351_0',
+            is_shown: true,
             parent_id: '3969471880322359761484771163',
             jdnHash: '6771529534322359778589411351',
             locator: {
@@ -106,6 +110,7 @@ export const locatorsTreeMock = [
         depth: 1,
         searchState: undefined,
         element_id: '4899732051322359779677566872_0',
+        is_shown: true,
         parent_id: '7967190244322359771369749968',
         jdnHash: '4899732051322359779677566872',
         locator: {
@@ -130,6 +135,7 @@ export const locatorsTreeMock = [
             depth: 2,
             searchState: undefined,
             element_id: '4829071593322359778594168519_0',
+            is_shown: true,
             parent_id: '4899732051322359779677566872',
             jdnHash: '4829071593322359778594168519',
             locator: {
@@ -154,6 +160,7 @@ export const locatorsTreeMock = [
                 depth: 3,
                 searchState: undefined,
                 element_id: '9636042053322359773245578788_0',
+                is_shown: true,
                 parent_id: '4829071593322359778594168519',
                 jdnHash: '9636042053322359773245578788',
                 locator: {
@@ -179,6 +186,7 @@ export const locatorsTreeMock = [
                 depth: 3,
                 searchState: undefined,
                 element_id: '8381553594322359777170267551_0',
+                is_shown: true,
                 parent_id: '4829071593322359778594168519',
                 jdnHash: '8381553594322359777170267551',
                 locator: {
@@ -208,6 +216,7 @@ export const locatorsTreeMock = [
         depth: 1,
         searchState: undefined,
         element_id: '4899732051322359779677566873_0',
+        is_shown: true,
         parent_id: '7967190244322359771369749968',
         jdnHash: '4899732051322359779677566873',
         locator: {
@@ -232,6 +241,7 @@ export const locatorsTreeMock = [
             depth: 2,
             searchState: undefined,
             element_id: '4829071593322359778594168522_0',
+            is_shown: true,
             parent_id: '4899732051322359779677566873',
             jdnHash: '4829071593322359778594168522',
             locator: {
@@ -256,6 +266,7 @@ export const locatorsTreeMock = [
                 depth: 3,
                 searchState: undefined,
                 element_id: '9636042053322359773245578777_0',
+                is_shown: true,
                 parent_id: '4829071593322359778594168522',
                 jdnHash: '9636042053322359773245578777',
                 locator: {
@@ -281,6 +292,7 @@ export const locatorsTreeMock = [
                 depth: 3,
                 searchState: undefined,
                 element_id: '8381553594322359777170267550_0',
+                is_shown: true,
                 parent_id: '4829071593322359778594168522',
                 jdnHash: '8381553594322359777170267550',
                 locator: {
@@ -312,6 +324,7 @@ export const locatorsTreeMock = [
     depth: 0,
     searchState: undefined,
     element_id: '796719024432235977136974900_0',
+    is_shown: true,
     parent_id: '',
     jdnHash: '796719024432235977136974900',
     locator: {

--- a/src/__tests__/locators/utils/__mocks__/locatorsTreeSearch.mock.ts
+++ b/src/__tests__/locators/utils/__mocks__/locatorsTreeSearch.mock.ts
@@ -6,6 +6,7 @@ export const locatorsTreeMockSearch = [
     depth: 0,
     searchState: 'hidden',
     element_id: '7967190244322359771369749968_0',
+    is_shown: true,
     parent_id: '',
     jdnHash: '7967190244322359771369749968',
     locator: {
@@ -30,6 +31,7 @@ export const locatorsTreeMockSearch = [
         depth: 2,
         searchState: 'none',
         element_id: '9636042053322359773245578777_0',
+        is_shown: true,
         parent_id: '4829071593322359778594168522',
         jdnHash: '9636042053322359773245578777',
         locator: {
@@ -57,6 +59,7 @@ export const locatorsTreeMockSearch = [
     depth: 0,
     searchState: 'none',
     element_id: '796719024432235977136974900_0',
+    is_shown: true,
     parent_id: '',
     jdnHash: '796719024432235977136974900',
     locator: {

--- a/src/__tests__/locators/utils/__mocks__/locatorsTreeSearchNamesTypes.mock.ts
+++ b/src/__tests__/locators/utils/__mocks__/locatorsTreeSearchNamesTypes.mock.ts
@@ -7,6 +7,7 @@ export const locatorsTreeMockSearchTypesNames = [
     depth: 0,
     searchState: SearchState.Hidden,
     element_id: '7967190244322359771369749968_0',
+    is_shown: true,
     parent_id: '',
     jdnHash: '7967190244322359771369749968',
     locator: {
@@ -31,6 +32,7 @@ export const locatorsTreeMockSearchTypesNames = [
         depth: 2,
         searchState: 'none',
         element_id: '4829071593322359778594168519_0',
+        is_shown: true,
         parent_id: '4899732051322359779677566872',
         jdnHash: '4829071593322359778594168519',
         locator: {
@@ -55,6 +57,7 @@ export const locatorsTreeMockSearchTypesNames = [
             depth: 3,
             searchState: 'none',
             element_id: '9636042053322359773245578788_0',
+            is_shown: true,
             parent_id: '4829071593322359778594168519',
             jdnHash: '9636042053322359773245578788',
             locator: {
@@ -80,6 +83,7 @@ export const locatorsTreeMockSearchTypesNames = [
             depth: 3,
             searchState: 'none',
             element_id: '8381553594322359777170267551_0',
+            is_shown: true,
             parent_id: '4829071593322359778594168519',
             jdnHash: '8381553594322359777170267551',
             locator: {
@@ -107,6 +111,7 @@ export const locatorsTreeMockSearchTypesNames = [
         depth: 2,
         searchState: 'none',
         element_id: '4829071593322359778594168522_0',
+        is_shown: true,
         parent_id: '4899732051322359779677566873',
         jdnHash: '4829071593322359778594168522',
         locator: {
@@ -131,6 +136,7 @@ export const locatorsTreeMockSearchTypesNames = [
             depth: 3,
             searchState: 'none',
             element_id: '9636042053322359773245578777_0',
+            is_shown: true,
             parent_id: '4829071593322359778594168522',
             jdnHash: '9636042053322359773245578777',
             locator: {
@@ -156,6 +162,7 @@ export const locatorsTreeMockSearchTypesNames = [
             depth: 3,
             searchState: 'none',
             element_id: '8381553594322359777170267550_0',
+            is_shown: true,
             parent_id: '4829071593322359778594168522',
             jdnHash: '8381553594322359777170267550',
             locator: {

--- a/src/__tests__/locators/utils/convertToListWithChildren.test.ts
+++ b/src/__tests__/locators/utils/convertToListWithChildren.test.ts
@@ -5,6 +5,7 @@ describe('convertToListWithChildren', () => {
   const inputList: Partial<ILocator>[] = [
     {
       element_id: '1',
+      is_shown: true,
       jdnHash: 'hash1',
       name: 'Element 1',
       parent_id: '',
@@ -12,6 +13,7 @@ describe('convertToListWithChildren', () => {
     },
     {
       element_id: '2',
+      is_shown: true,
       jdnHash: 'hash2',
       name: 'Element 2',
       parent_id: 'hash1',
@@ -19,6 +21,7 @@ describe('convertToListWithChildren', () => {
     },
     {
       element_id: '3',
+      is_shown: true,
       jdnHash: 'hash3',
       name: 'Element 3',
       parent_id: 'hash2',
@@ -26,6 +29,7 @@ describe('convertToListWithChildren', () => {
     },
     {
       element_id: '4',
+      is_shown: true,
       jdnHash: 'hash4',
       name: 'Element 4',
       parent_id: '',
@@ -36,6 +40,7 @@ describe('convertToListWithChildren', () => {
   const expectedOutput: Partial<ILocator>[] = [
     {
       element_id: '1',
+      is_shown: true,
       jdnHash: 'hash1',
       name: 'Element 1',
       parent_id: '',
@@ -44,6 +49,7 @@ describe('convertToListWithChildren', () => {
     },
     {
       element_id: '2',
+      is_shown: true,
       jdnHash: 'hash2',
       name: 'Element 2',
       parent_id: 'hash1',
@@ -52,6 +58,7 @@ describe('convertToListWithChildren', () => {
     },
     {
       element_id: '3',
+      is_shown: true,
       jdnHash: 'hash3',
       name: 'Element 3',
       parent_id: 'hash2',
@@ -60,6 +67,7 @@ describe('convertToListWithChildren', () => {
     },
     {
       element_id: '4',
+      is_shown: true,
       jdnHash: 'hash4',
       name: 'Element 4',
       parent_id: '',
@@ -71,6 +79,7 @@ describe('convertToListWithChildren', () => {
   const inputList2: Partial<ILocator>[] = [
     {
       element_id: '1',
+      is_shown: true,
       jdnHash: 'hash1',
       name: 'Element 1',
       parent_id: '',
@@ -78,12 +87,14 @@ describe('convertToListWithChildren', () => {
     },
     {
       element_id: '2',
+      is_shown: true,
       jdnHash: 'hash2',
       name: 'Element 2',
       isGenerated: true,
     },
     {
       element_id: '3',
+      is_shown: true,
       jdnHash: 'hash3',
       name: 'Element 3',
       parent_id: 'hash2',
@@ -93,6 +104,7 @@ describe('convertToListWithChildren', () => {
   const expectedOutput2: Partial<ILocator>[] = [
     {
       element_id: '1',
+      is_shown: true,
       jdnHash: 'hash1',
       name: 'Element 1',
       parent_id: '',
@@ -101,6 +113,7 @@ describe('convertToListWithChildren', () => {
     },
     {
       element_id: '2',
+      is_shown: true,
       jdnHash: 'hash2',
       name: 'Element 2',
       isGenerated: true,
@@ -108,6 +121,7 @@ describe('convertToListWithChildren', () => {
     },
     {
       element_id: '3',
+      is_shown: true,
       jdnHash: 'hash3',
       name: 'Element 3',
       parent_id: 'hash2',

--- a/src/__tests__/locators/utils/sortLocatorsWithChildren.test..ts
+++ b/src/__tests__/locators/utils/sortLocatorsWithChildren.test..ts
@@ -5,29 +5,35 @@ describe('sortLocatorsWithChildren', () => {
   const input = [
     {
       element_id: '1',
+      is_shown: true,
       children: ['2', '5'],
     },
     {
       element_id: '4',
+      is_shown: true,
       children: [],
     },
     {
       element_id: '2',
+      is_shown: true,
       children: ['3'],
       parent_id: '1',
     },
     {
       element_id: '3',
+      is_shown: true,
       children: [],
       parent_id: '2',
     },
     {
       element_id: '5',
+      is_shown: true,
       children: ['8'],
       parent_id: '1',
     },
     {
       element_id: '6',
+      is_shown: true,
       children: [],
       parent_id: '7',
     },
@@ -35,29 +41,35 @@ describe('sortLocatorsWithChildren', () => {
   const expectedOutput = [
     {
       element_id: '1',
+      is_shown: true,
       children: ['2', '5'],
     },
     {
       element_id: '2',
+      is_shown: true,
       children: ['3'],
       parent_id: '1',
     },
     {
       element_id: '3',
+      is_shown: true,
       children: [],
       parent_id: '2',
     },
     {
       element_id: '5',
+      is_shown: true,
       children: ['8'],
       parent_id: '1',
     },
     {
       element_id: '4',
+      is_shown: true,
       children: [],
     },
     {
       element_id: '6',
+      is_shown: true,
       children: [],
       parent_id: '7',
     },

--- a/src/__tests__/pageObject/__mocks__/selectLocatorsByPageObject.mock.ts
+++ b/src/__tests__/pageObject/__mocks__/selectLocatorsByPageObject.mock.ts
@@ -59,6 +59,7 @@ export const getRootState = (_pageObject: PageObject) => ({
       entities: {
         '7524916072510597399809892823_0': {
           element_id: '7524916072510597399809892823_0',
+          is_shown: true,
           predicted_label: 'dialog',
           jdnHash: '7524916072510597399809892823',
           pageObj: 0,
@@ -82,6 +83,7 @@ export const getRootState = (_pageObject: PageObject) => ({
         },
         '2075611903510597386448924232_0': {
           element_id: '2075611903510597386448924232_0',
+          is_shown: true,
           predicted_label: 'list',
           jdnHash: '2075611903510597386448924232',
           pageObj: 0,
@@ -108,6 +110,7 @@ export const getRootState = (_pageObject: PageObject) => ({
         },
         '4138940493550098806301857686_0': {
           element_id: '4138940493550098806301857686_0',
+          is_shown: true,
           predicted_label: 'menu',
           jdnHash: '4138940493550098806301857686',
           pageObj: 0,
@@ -138,6 +141,7 @@ export const getRootState = (_pageObject: PageObject) => ({
 export const selectMockedLocators = (pageObject: PageObject) => [
   {
     element_id: '7524916072510597399809892823_0',
+    is_shown: true,
     predicted_label: 'dialog',
     jdnHash: '7524916072510597399809892823',
     pageObj: 0,
@@ -162,6 +166,7 @@ export const selectMockedLocators = (pageObject: PageObject) => [
   },
   {
     element_id: '2075611903510597386448924232_0',
+    is_shown: true,
     predicted_label: 'list',
     jdnHash: '2075611903510597386448924232',
     pageObj: 0,
@@ -193,6 +198,7 @@ export const selectMockedLocators = (pageObject: PageObject) => [
   },
   {
     element_id: '4138940493550098806301857686_0',
+    is_shown: true,
     predicted_label: 'menu',
     jdnHash: '4138940493550098806301857686',
     pageObj: 0,

--- a/src/app/utils/compatibleVersions.ts
+++ b/src/app/utils/compatibleVersions.ts
@@ -1,3 +1,3 @@
 export const compatibleMajorVer = 0;
 export const compatibleMinorVer = 2;
-export const compatibleBuildVer = 40;
+export const compatibleBuildVer = 41;

--- a/src/common/utils/getDocument.ts
+++ b/src/common/utils/getDocument.ts
@@ -1,6 +1,0 @@
-import connector from '../../pageServices/connector';
-
-export const getDocument = async () => {
-  const documentResult = await connector.attachContentScript(() => JSON.stringify(document.documentElement.innerHTML));
-  return await documentResult[0].result;
-};

--- a/src/common/utils/getFullDocument.ts
+++ b/src/common/utils/getFullDocument.ts
@@ -1,0 +1,6 @@
+import connector from '../../pageServices/connector';
+
+export const getFullDocument = async () => {
+  const documentResult = await connector.attachContentScript(() => JSON.stringify(document.documentElement.outerHTML));
+  return await documentResult[0].result;
+};

--- a/src/features/locators/reducers/identifyElements.thunk.ts
+++ b/src/features/locators/reducers/identifyElements.thunk.ts
@@ -37,12 +37,14 @@ export const identifyElements = createAsyncThunk('locators/identifyElements', as
     const endpoint = predictEndpoints[library];
     const { data: res, pageData } =
       library !== ElementLibrary.Vuetify ? await predictElements(endpoint) : await findByRules();
-    const locators = res.map((el: PredictedEntity) => ({
-      ...el,
-      element_id: `${el.element_id}_${pageObj}`,
-      jdnHash: el.element_id,
-      pageObj: pageObj,
-    }));
+    const locators = res
+      .filter((el: PredictedEntity) => el.is_shown)
+      .map((el: PredictedEntity) => ({
+        ...el,
+        element_id: `${el.element_id}_${pageObj}`,
+        jdnHash: el.element_id,
+        pageObj: pageObj,
+      }));
 
     thunkAPI.dispatch(setPageData({ id: pageObj, pageData }));
     thunkAPI.dispatch(createLocators({ predictedElements: locators, library }));

--- a/src/features/locators/types/locator.types.ts
+++ b/src/features/locators/types/locator.types.ts
@@ -108,4 +108,5 @@ export interface ILocator extends PredictedEntity {
 export interface PredictedEntity {
   element_id: ElementId;
   predicted_label: string;
+  is_shown: boolean;
 }

--- a/src/features/locators/utils/constants.ts
+++ b/src/features/locators/utils/constants.ts
@@ -22,6 +22,7 @@ export const newLocatorStub: ILocator = {
   elemName: '',
   elemText: '',
   element_id: '',
+  is_shown: true,
   jdnHash: '',
   parent_id: '',
   locator: {

--- a/src/features/locators/utils/locatorGenerationController.ts
+++ b/src/features/locators/utils/locatorGenerationController.ts
@@ -1,7 +1,7 @@
 import { WebSocketMessage } from '../../../services/backend';
 import { JDNHash, ILocator, LocatorTaskStatus } from '../types/locator.types';
 import { webSocketController } from '../../../services/webSocketController';
-import { getDocument } from '../../../common/utils/getDocument';
+import { getFullDocument } from '../../../common/utils/getFullDocument';
 import { MainState, MaxGenerationTime } from '../../../app/types/mainSlice.types';
 import { PageObject } from '../../pageObjects/types/pageObjectSlice.types';
 
@@ -29,7 +29,7 @@ class LocatorGenerationController {
     maxGenerationTime?: MaxGenerationTime,
   ) {
     if (pageObject) this.pageObject = pageObject;
-    this.document = await getDocument();
+    this.document = await getFullDocument();
 
     const hashes = elements.map((element) => element.jdnHash);
 

--- a/src/pageServices/pageDataHandlers.js
+++ b/src/pageServices/pageDataHandlers.js
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import connector, { sendMessage } from './connector';
 import { request } from '../services/backend';
 import { createOverlay } from './contentScripts/createOverlay';
+import { getFullDocument } from '../common/utils/getFullDocument';
 /* global chrome*/
 
 let overlayID;
@@ -34,11 +36,10 @@ And then tha data is sent to endpoint, according to selected library.
 Function returns predicted elements. */
 export const predictElements = (endpoint) => {
   let pageData;
-  return sendMessage
-    .getPageData()
-    .then((data) => {
+  return Promise.all([sendMessage.getPageData(), getFullDocument()])
+    .then(([data, document]) => {
       pageData = data[0];
-      return sendToModel(pageData, endpoint);
+      return sendToModel({ elements: pageData, document }, endpoint);
     })
     .then(
       (response) => {


### PR DESCRIPTION
https://github.com/jdi-testing/jdn-ai/issues/1287
original PR: https://github.com/jdi-testing/jdn-ai/pull/1391

- updated FE for using new "-predict" endpoint 
- updated minimum compatible version of BE: `0.2.41`