### PR TITLE
issue 1377: styles for ContextMenu animation on Coverage Panel

### DIFF
--- a/src/pageServices/contentScripts/css/contextMenu.less
+++ b/src/pageServices/contentScripts/css/contextMenu.less
@@ -16,7 +16,7 @@ div[id^="jdn_cm_"] {
     opacity: 0;
     transform: scale(0);
     transition: transform 0.1s;
-    transform-origin: top left;
+    transform-origin: center;
     font-family: "Source Sans Pro", sans-serif;
     font-size: 12px;
     z-index: 16000;


### PR DESCRIPTION
https://github.com/jdi-testing/jdn-ai/issues/1377
Changed the styles of the opening animation for the Сontext Menu on the Coverage Panel - now the animations for the context menu always go from the **center**.

https://github.com/jdi-testing/jdn-ai/assets/50149163/701919b6-ab7d-4168-aa79-6a4b61b14ca1

